### PR TITLE
Elyra hands-on exercise: add default pipeline parameter values

### DIFF
--- a/5.pipelines/elyra/data_ingestion.py
+++ b/5.pipelines/elyra/data_ingestion.py
@@ -11,7 +11,7 @@ def ingest_data(data_object_name='', data_folder='./data'):
     s3_secret_key = environ.get('AWS_SECRET_ACCESS_KEY')
     s3_bucket_name = environ.get('AWS_S3_BUCKET')
     data_object_name = data_object_name or environ.get(
-        'data_object_name'
+        'data_object_name', 'live-data.csv'
     )
 
     print(f'Downloading data "{data_object_name}" '

--- a/5.pipelines/elyra/model_loading.py
+++ b/5.pipelines/elyra/model_loading.py
@@ -10,7 +10,9 @@ def load_model(model_file_name=''):
     s3_access_key = environ.get('AWS_ACCESS_KEY_ID')
     s3_secret_key = environ.get('AWS_SECRET_ACCESS_KEY')
     s3_bucket_name = environ.get('AWS_S3_BUCKET')
-    model_object_name = model_file_name or environ.get('model_object_name')
+    model_object_name = model_file_name or environ.get(
+        'model_object_name', 'model-latest.onnx'
+    )
 
     print(f'Downloading model "{model_object_name}" '
           f'from bucket {s3_bucket_name} '


### PR DESCRIPTION
Added fallback values for `data_object_name` in data_ingestion and `model_object_name` in model_loading. These would normally be set using pipeline parameters. However, for simplicity pipeline parameters are not covered in this lab. To avoid issues running the pipeline, we're defining default values, which refer to the artefacts used in this lab.