### PR TITLE
Remove diff function from histogram display

### DIFF
--- a/3.create-model/pytorch-lab/notebooks/01-data-exploration.ipynb
+++ b/3.create-model/pytorch-lab/notebooks/01-data-exploration.ipynb
@@ -132,7 +132,7 @@
    "source": [
     "# Plot histograms of the columns on multiple subplots\n",
     "plt.close('all')\n",
-    "df.diff().hist(color=\"k\", alpha=0.5, bins=20, figsize=(15, 10))"
+    "df.hist(color=\"k\", alpha=0.5, bins=20, figsize=(15, 10))"
    ]
   },
   {


### PR DESCRIPTION
The diff function is not needed and causing unnecessary confusion