### PR TITLE
Change pytorch_model location

### DIFF
--- a/1.intro/chapter1/intro-text-generation/notebook.ipynb
+++ b/1.intro/chapter1/intro-text-generation/notebook.ipynb
@@ -569,7 +569,7 @@
     "## Download Model (ONLY if `DO_TRAIN` is False)\n",
     "If `DO_TRAIN` is False, you need to download the model before testing it.\n",
     "\n",
-    "Download the [pytorch_model.bin](https://drive.google.com/file/d/142H5pfiw7JKN29xv9rav1ZTDF2a8MCoZ/view?usp=sharing) from Google Drive file into your computer.\n",
+    "Download the [pytorch_model.bin](https://github.com/RedHatQuickCourses/rhods-qc-apps/releases/download/v2.8.0/pytorch_model.bin) file from GitHub into your computer.\n",
     "Then, upload the file into the `my_model/` directory of this workspace.\n",
     "\n",
     "Wait for the file to upload.\n",


### PR DESCRIPTION
This file was previously available in Gdrive, which restricted access to non RH accounts. The file is now publicly available as part of a [GH release](https://github.com/RedHatQuickCourses/rhods-qc-apps/releases/tag/v2.8.0) in this repository.