### PR TITLE
Elyra Pipelines update for RHOAI 2.11

### DIFF
--- a/5.pipelines/elyra/data_ingestion.py
+++ b/5.pipelines/elyra/data_ingestion.py
@@ -32,4 +32,4 @@ def ingest_data(data_object_name='', data_folder='./data'):
 
 
 if __name__ == '__main__':
-    ingest_data(data_folder='/data')
+    ingest_data(data_folder='.')

--- a/5.pipelines/elyra/preprocessing.py
+++ b/5.pipelines/elyra/preprocessing.py
@@ -30,4 +30,4 @@ def preprocess(data_folder='./data'):
 
 
 if __name__ == '__main__':
-    preprocess(data_folder='/data')
+    preprocess(data_folder='.')

--- a/5.pipelines/elyra/results_upload.py
+++ b/5.pipelines/elyra/results_upload.py
@@ -30,4 +30,4 @@ def upload_results(data_folder='./data'):
 
 
 if __name__ == '__main__':
-    upload_results(data_folder='/data')
+    upload_results(data_folder='.')

--- a/5.pipelines/elyra/scoring.py
+++ b/5.pipelines/elyra/scoring.py
@@ -27,4 +27,4 @@ def predict(data_folder='./data'):
 
 
 if __name__ == '__main__':
-    predict(data_folder='/data')
+    predict(data_folder='.')

--- a/5.pipelines/minio-fraud-detection.yaml
+++ b/5.pipelines/minio-fraud-detection.yaml
@@ -1,0 +1,142 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: minio-fraud-detection-secret
+  namespace: minio
+stringData:
+  accesskey: minio
+  secretkey: minio123
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: minio-fraud-detection
+  namespace: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio-fraud-detection
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: minio-fraud-detection
+    spec:
+      containers:
+        - resources:
+            limits:
+              cpu: 250m
+              memory: 1Gi
+            requests:
+              cpu: 20m
+              memory: 100Mi
+          readinessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          name: minio-models
+          livenessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          env:
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: minio-fraud-detection-secret
+                  key: accesskey
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: minio-fraud-detection-secret
+                  key: secretkey
+          ports:
+            - containerPort: 9000
+              protocol: TCP
+            - containerPort: 9090
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
+          terminationMessagePolicy: File
+          image: quay.io/mmurakam/minio:fraud-detection-v0.1.1
+          args:
+            - server
+            - /data1
+            - --console-address
+            - :9090
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: minio-fraud-detection-service
+  namespace: minio
+spec:
+  ipFamilies:
+    - IPv4
+  ports:
+    - name: api
+      protocol: TCP
+      port: 9000
+      targetPort: 9000
+    - name: ui
+      protocol: TCP
+      port: 9090
+      targetPort: 9090
+  internalTrafficPolicy: Cluster
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  sessionAffinity: None
+  selector:
+    app: minio-fraud-detection
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: minio-api
+  namespace: minio
+spec:
+  to:
+    kind: Service
+    name: minio-fraud-detection-service
+    weight: 100
+  port:
+    targetPort: api
+  wildcardPolicy: None
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: minio-ui
+  namespace: minio
+spec:
+  to:
+    kind: Service
+    name: minio-fraud-detection-service
+    weight: 100
+  port:
+    targetPort: ui
+  wildcardPolicy: None
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect


### PR DESCRIPTION
Part of pipelines rework as required by upgrade from Kubeflow Pipelines v1 to v2 in RHOAI 2.9 (https://github.com/RedHatQuickCourses/rhods-pipelines/issues/29).

The new Minio instance comes with built-in data and model artifacts to simplify S3 setup for the pipelines chapter.